### PR TITLE
Bump package versions and export new hooks

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@razorlabs/razorkit",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "type": "module",
   "files": [
     "dist"

--- a/packages/kit/src/hooks/index.ts
+++ b/packages/kit/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useAbi';
+export * from './useAccount';
 export * from './useAccountBalance';
 export * from './useAutoConnect';
 export * from './useAvailableWallets';
@@ -11,6 +12,7 @@ export * from './useSignAndSubmitTransaction';
 export * from './useSignMessage';
 export * from './useSignTransaction';
 export * from './useSimulateFunction';
+export * from './useSwitchChain';
 export * from './useViewFunction';
 export * from './useWaitForTransactionResponse';
 export * from './useWallet';

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@razorlabs/wallet-sdk",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
- Incremented version to 1.0.9 for @razorlabs/razorkit and @razorlabs/wallet-sdk
- Added exports for `useAccount` and `useSwitchChain` hooks in kit package