### PR TITLE
Update indexer URLs for Movement chains

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@razorlabs/razorkit",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "type": "module",
   "files": [
     "dist"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@razorlabs/wallet-sdk",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/sdk/src/chain/constants.ts
+++ b/packages/sdk/src/chain/constants.ts
@@ -11,14 +11,14 @@ export const MovementBardockTestnetChain: Chain = {
   id: 250,
   name: 'Movement Bardock Testnet',
   rpcUrl: 'https://aptos.testnet.bardock.movementlabs.xyz/v1',
-  indexerUrl: 'https://rpc.sentio.xyz/movement-testnet-indexer/v1/graphql'
+  indexerUrl: 'https://indexer.testnet.movementnetwork.xyz/v1/graphql',
 };
 
 export const MovementMainnetChain: Chain = {
   id: 126,
   name: 'Movement Mainnet',
   rpcUrl: 'https://mainnet.movementnetwork.xyz/v1',
-  indexerUrl: 'https://rpc.sentio.xyz/movement-indexer/v1/graphql',
+  indexerUrl: 'https://indexer.mainnet.movementnetwork.xyz/v1/graphql',
 };
 
 export const UnknownChain: Chain = {


### PR DESCRIPTION
- Updated indexer URLs for Movement Bardock Testnet and Movement Mainnet
- Bumped package versions to 1.0.10 for @razorlabs/razorkit and @razorlabs/wallet-sdk